### PR TITLE
Remove instance variables

### DIFF
--- a/processor.rb
+++ b/processor.rb
@@ -5,12 +5,11 @@ class Processor
   def initialize(input_filename, output_filename)
     @dictionary = get_words_from_file(input_filename)
     @output_filename = output_filename
-    @pairs_hash = Hash.new { |pairs_hash, sequence| pairs_hash[sequence] = [] }
   end
 
   def create_list
-    create_sequence_word_pairs
-    unique_sequences = select_unique_sequences(@pairs_hash)
+    sequence_word_pairs = create_sequence_word_pairs
+    unique_sequences = select_unique_sequences(sequence_word_pairs)
     alphabetize_pairs_by_sequence(unique_sequences)
   end
 
@@ -29,10 +28,12 @@ class Processor
   end
 
   def create_sequence_word_pairs
+    pairs_hash = Hash.new { |pairs_hash, sequence| pairs_hash[sequence] = [] }
     @dictionary.each do |word|
       extracted_sequences = all_sequences(word)
-      extracted_sequences.each { |sequence| @pairs_hash[sequence] << word }
+      extracted_sequences.each { |sequence| pairs_hash[sequence] << word }
     end
+    pairs_hash
   end
 
   def select_unique_sequences(sequence_word_pairs)

--- a/processor.rb
+++ b/processor.rb
@@ -8,7 +8,7 @@ class Processor
   end
 
   def create_list
-    sequence_word_pairs = create_sequence_word_pairs
+    sequence_word_pairs = create_sequence_word_pairs(@dictionary)
     unique_sequences = select_unique_sequences(sequence_word_pairs)
     alphabetize_pairs_by_sequence(unique_sequences)
   end
@@ -27,9 +27,9 @@ class Processor
     sequences
   end
 
-  def create_sequence_word_pairs
+  def create_sequence_word_pairs(words)
     pairs_hash = Hash.new { |pairs_hash, sequence| pairs_hash[sequence] = [] }
-    @dictionary.each do |word|
+    words.each do |word|
       extracted_sequences = all_sequences(word)
       extracted_sequences.each { |sequence| pairs_hash[sequence] << word }
     end

--- a/processor.rb
+++ b/processor.rb
@@ -10,7 +10,7 @@ class Processor
 
   def create_list
     create_sequence_word_pairs
-    unique_sequences = select_unique_sequences
+    unique_sequences = select_unique_sequences(@pairs_hash)
     alphabetize_pairs_by_sequence(unique_sequences)
   end
 
@@ -35,8 +35,8 @@ class Processor
     end
   end
 
-  def select_unique_sequences
-    @pairs_hash.select do |sequence, duplicate_words_array|
+  def select_unique_sequences(sequence_word_pairs)
+    sequence_word_pairs.select do |sequence, duplicate_words_array|
       duplicate_words_array.length == 1
     end
   end

--- a/processor.rb
+++ b/processor.rb
@@ -5,7 +5,6 @@ class Processor
   def initialize(input_filename, output_filename)
     @dictionary = get_words_from_file(input_filename)
     @output_filename = output_filename
-    @sequences = []
     @pairs_hash = Hash.new { |pairs_hash, sequence| pairs_hash[sequence] = [] }
   end
 
@@ -20,13 +19,13 @@ class Processor
   end
 
   def all_sequences(word)
-    @sequences = []
+    sequences = []
     while word.length > 3
       four_letter_sequence = word[0..3]
-      @sequences << four_letter_sequence
+      sequences << four_letter_sequence
       word = word[1..-1]
     end
-    return @sequences
+    sequences
   end
 
   def create_sequence_word_pairs

--- a/processor.rb
+++ b/processor.rb
@@ -10,8 +10,8 @@ class Processor
 
   def create_list
     create_sequence_word_pairs
-    select_unique_sequences
-    alphabetize_pairs_by_sequence
+    unique_sequences = select_unique_sequences
+    alphabetize_pairs_by_sequence(unique_sequences)
   end
 
   def get_words_from_file(input_filename)
@@ -41,8 +41,8 @@ class Processor
     end
   end
 
-  def alphabetize_pairs_by_sequence
-    select_unique_sequences.sort_by { |sequence, word| sequence.downcase }
+  def alphabetize_pairs_by_sequence(unique_sequences)
+    unique_sequences.sort_by { |sequence, word| sequence.downcase }
   end
 
   # def output_to_file


### PR DESCRIPTION
This removes most of the instance variables in favor of changing the `create_sequence_word_pairs`, `select_unique_sequences`, and `alphabetize_pairs_by_sequence` methods to take an input and return an output.
`create_list` has been changed to take the output of each method and pass it in to the next part of the process.

This helps to clearly identify the purpose of each individual method, and will also help with testing because it is now possible to call a method without relying on or affecting the value of an instance variable, eg. repeated calls to `create_sequence_word_pairs` with the same input will always return the same output, whereas before these changes, calling it more than once would have resulted in duplicate values being put in `@pairs_hash`.
